### PR TITLE
get-document-revision is broken

### DIFF
--- a/src/core/document.lisp
+++ b/src/core/document.lisp
@@ -29,14 +29,12 @@
   "Quickly fetches the latest revision for DOC-ID. If ERRORP is NIL, this can be used to quickly
 test the existence of a document."
   (multiple-value-bind (x status-code headers)
-      (http-request (strcat (server-uri (database-server db))
-                            (database-name db)
-                            (url-encode (princ-to-string doc-id)))
+      (http-request (strcat (db-uri db) "/" (url-encode (princ-to-string doc-id)))
                     :method :head)
     (declare (ignore x))
     (case (or (cdr (assoc status-code +status-codes+ :test #'=))
               (error "Unknown status code: ~A." status-code))
-      (:ok (cdr (assoc :etag headers)))
+      (:ok (dequote (cdr (assoc :etag headers))))
       (:not-found (when errorp (error 'document-not-found :db db :id doc-id))))))
 
 (defun get-document (db id &key attachmentsp (errorp t) params)

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -1,7 +1,7 @@
 (cl:defpackage :chillax.utils
   (:use :cl :alexandria)
   (:export
-   :fun :mkhash :hashget :strcat :at))
+   :fun :mkhash :hashget :strcat :dequote :at))
 (in-package :chillax.utils)
 
 ;;; Functions
@@ -43,6 +43,12 @@ tl;dr: DWIM SETF function for HASHGET."
 ;;; Strings
 (defun strcat (string &rest more-strings)
   (apply #'concatenate 'string string more-strings))
+
+(defun dequote (string)
+  (let ((len (length string)))
+    (if (and (> len 1) (starts-with #\" string) (ends-with #\" string))
+      (subseq string 1 (- len 1))
+      string)))
 
 ;;;
 ;;; At


### PR DESCRIPTION
attached commit fixes two things:
1. missing slash between database name and document id
2. rev is returned as a quoted string, need to unquote
